### PR TITLE
コマンドラインオプションで grep オプションが指定された場合の処理を追加する．

### DIFF
--- a/src/main/resouces/Finder.java
+++ b/src/main/resouces/Finder.java
@@ -1,8 +1,11 @@
 package com.github.finder;
 
 import java.io.File;
+import java.io.BufferedReader;
+import java.io.FileReader;
 import java.util.ArrayList;
 import java.util.List;
+
 
 public class Finder {
     private Args args;
@@ -80,4 +83,38 @@ public class Finder {
             }
         }
     }
+
+    //grep-option
+    private boolean isTarget(File file){
+        boolean flag = true;
+        if(args.getName() != null){
+            flag &= checkTargetName(file, args.getName());
+        }
+        if(args.getType() != null){
+            flag &= checkTargetType(file, args.getType());
+        }
+        if(args.getSize() != null){
+            flag &= checkTargetSize(file, args.getSize());
+        }
+        if(args.getGrep() != null){
+            flag &= checkGrep(file, args.getGrep());
+        }
+        
+        return flag;
+    }
+    
+    private boolean checkGrep(File file, String pattern){
+        if(file.isFile()){
+            try(BufferedReader in = new BufferedReader(new FileReader(file))){
+                String line;
+                while((line = in.readLine()) != null){
+                    if(line.indexOf(pattern) >= 0){
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
 }


### PR DESCRIPTION
grepオプションは，ファイルの中身を検索し，指定された文字列が含まれたファイルであれば結果に含めるものとする．
ファイルはテキストファイルであると決め打ちで読むこととする．
検査対象がディレクトリの場合は，常に false を返す．

importの追加があっているか自信がないので、確認お願いします。
importについてコメントお願いします。
